### PR TITLE
require_secure_transport var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ mysql_innodb_lock_wait_timeout: 50
 mysql_innodb_log_file_size: "128M"
 
 mysql_log_error_verbosity: 2
+
+mysql_require_secure_transport: On
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ mysql_innodb_log_file_size: "128M"
 
 mysql_log_error_verbosity: 2
 
-mysql_require_secure_transport: On
+mysql_require_secure_transport: ON
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,4 +18,4 @@ mysql_innodb_log_file_size: "128M"
 
 mysql_log_error_verbosity: 2
 
-mysql_require_secure_transport: On
+mysql_require_secure_transport: ON

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,5 @@ mysql_innodb_lock_wait_timeout: 50
 mysql_innodb_log_file_size: "128M"
 
 mysql_log_error_verbosity: 2
+
+mysql_require_secure_transport: On

--- a/templates/custom.cnf
+++ b/templates/custom.cnf
@@ -10,7 +10,7 @@ slow_query_log_file = /var/log/mysql/mysql-slow.log
 long_query_time = 4
 bind-address = {{ mysql_bind_address }}
 max_allowed_packet = 64M
-require_secure_transport = ON
+require_secure_transport = {{ mysql_require_secure_transport }}
 
 #
 # * InnoDB


### PR DESCRIPTION
Currently there's a mismatch between live and build servers because of the lack of this option.